### PR TITLE
Add support Symfony 5 for controller

### DIFF
--- a/src/LightSaml/SpBundle/Resources/config/services.yml
+++ b/src/LightSaml/SpBundle/Resources/config/services.yml
@@ -3,6 +3,12 @@ parameters:
     lightsaml.route.login_check: lightsaml_sp.login_check
 
 services:
+    LightSaml\SpBundle\Controller\DefaultController:
+        public: true
+        tags: [ 'controller.service_arguments' ]
+        arguments:
+            $discoveryRoute: "%lightsaml_sp.route.discovery%"
+
     lightsaml_sp.username_mapper.simple:
         class: LightSaml\SpBundle\Security\User\SimpleUsernameMapper
         arguments:


### PR DESCRIPTION
Fixing error on Mautic 5.0.0-alpha1 branch.

```
[Symfony\Component\ErrorHandler\Error\ClassNotFoundError]                                         
  Attempted to load class "Controller" from namespace "Symfony\Bundle\FrameworkBundle\Controller".  
  Did you forget a "use" statement for another namespace?
```

For reproducing just run `php bin/console debug:route` on branch 5.0.0-alpha1