### PR TITLE
Add missing service arguments to controller

### DIFF
--- a/src/LightSaml/SpBundle/Resources/config/services.yml
+++ b/src/LightSaml/SpBundle/Resources/config/services.yml
@@ -6,7 +6,13 @@ services:
     LightSaml\SpBundle\Controller\DefaultController:
         public: true
         tags: [ 'controller.service_arguments' ]
+        calls:
+            - [ setContainer, [ "@service_container" ] ]
         arguments:
+            $metadataProfileBuilder: '@ligthsaml.profile.metadata'
+            $profileLoginFactory: '@ligthsaml.profile.login_factory'
+            $storeContainer: "@lightsaml.container.store"
+            $partyContainer: "@lightsaml.container.party"
             $discoveryRoute: "%lightsaml_sp.route.discovery%"
 
     lightsaml_sp.username_mapper.simple:


### PR DESCRIPTION
This fixes errors like
```
php.CRITICAL: Uncaught Error: LightSaml\SpBundle\Controller\DefaultController::__construct(): Argument #1 ($metadataProfileBuilder) not passed {"exception":"[object] (ArgumentCountError(code: 0): LightSaml\\SpBundle\\Controller\\DefaultController::__construct(): Argument #1 ($metadataProfileBuilder) not passed at /var/www/html/vendor/lightsaml/sp-bundle/src/LightSaml/SpBundle/Controller/DefaultController.php:29)"} {"hostname":"xxx","pid":46}
```

see e.g. https://github.com/mautic/mautic/issues/13361